### PR TITLE
[semver:patch] Add //empty to jq

### DIFF
--- a/src/commands/until_front_of_line.yml
+++ b/src/commands/until_front_of_line.yml
@@ -77,7 +77,7 @@ steps:
 
         fetch_active_workflows(){
           cp /tmp/jobstatus.json /tmp/augmented_jobstatus.json
-          for workflow in `jq -r ".[] | .workflows.workflow_id" /tmp/augmented_jobstatus.json | uniq`
+          for workflow in `jq -r ".[] | .workflows.workflow_id //empty" /tmp/augmented_jobstatus.json | uniq`
           do
             echo "Checking time of workflow: ${workflow}"
             workflow_file=/tmp/workflow-${workflow}.json


### PR DESCRIPTION
Hey! Thanks for sharing this orb. I had an issue while running it, that's how my log looked:
```
master queueable
This build will block until all previous builds complete.
Max Queue Time: 30 minutes.
Only blocking execution if running previous jobs on branch: master
Attempting to access CircleCI api. If the build process fails after this step, ensure your CIRCLECI_API_KEY is set.
API access successful
Checking time of workflow: 930c7968-9e9e-4bb3-a0bf-5b5748bb64da
Workflow was created at: 2021-01-21T10:49:30Z
Checking time of workflow: null
```

I've SSHed to machine, run the jq command from the script and I did get this:
```
930c7968-9e9e-4bb3-a0bf-5b5748bb64da
null
```

Adding //empty to the same command resulted in correct output:
```
930c7968-9e9e-4bb3-a0bf-5b5748bb64da
```

### Checklist

<!--
	thank you for contributing to CircleCI Concurrency Control Orb!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
